### PR TITLE
Add encoder plan caching to improve runtime without --release. Add par_iter to decode step. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ Cargo.lock
 **/*.rs.bk
 
 *.code-workspace
+
+# ignore hidden files and directories
+.*
+!/.gitignore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0"
+flate2 = "1.0"
 num-format = "0.4"
 raptorq = { version = "1.6", features = ["serde_support"] }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ name = "raptor_cdn_lib"
 path = "src/lib.rs"
 
 [dependencies]
-raptorq = "1.6"
+anyhow = "1.0"
+num-format = "0.4"
+raptorq = { version = "1.6", features = ["serde_support"] }
 rand = "0.8"
 rayon = "1.5"
-num-format = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/codec/consts.rs
+++ b/src/codec/consts.rs
@@ -1,15 +1,15 @@
 /*
  * Constants defined in the RPC spec are prefixed with RAPTORQ_
- * Other constants are defined by the encoder implementation. 
+ * Other constants are defined by the encoder implementation.
  */
-// source block number limit as defined in the raptorq spec, but a little less. 
+// source block number limit as defined in the raptorq spec, but a little less.
 pub const RAPTORQ_ENCODING_SYMBOL_ID_MAX: usize = 1 << 23;
 
-/// Maximum symbols we allow in a block. This should be less than 56403, which is the maximum symbol per block allowed by raptorq. 
-pub const MAX_SYMBOLS_IN_BLOCK: usize = 1024;
+/// Maximum symbols we allow in a block. This should be less than 56403, which is the maximum symbol per block allowed by raptorq.
+pub const MAX_SYMBOLS_IN_BLOCK: u16 = 1024;
 
 /// Alignment of symbols in memory in bytes.
 pub const ALIGNMENT: u8 = 8;
 
-// We enforce a minimum packet size for our encoder - not specified in RFC, but it makes code easier. 
+// We enforce a minimum packet size for our encoder - not specified in RFC, but it makes code easier.
 pub const MIN_PACKET_SIZE: u16 = 512;

--- a/src/codec/decoder.rs
+++ b/src/codec/decoder.rs
@@ -1,20 +1,14 @@
-#[cfg(feature = "serde_support")]
-use serde::{Deserialize, Serialize};
-use raptorq::{
-    EncodingPacket, SourceBlockDecoder,
-};
+use raptorq::{EncodingPacket, SourceBlockDecoder};
+use rayon::prelude::*;
 
-use super::encoder::{
-    BlockInfo,
-    EncodedBlock,
-};
+use super::encoder::{BlockInfo, EncodedBlock};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RaptorQDecoderError {
-    /// TODO: make errors more useful. 
+    /// TODO: make errors more useful.
     BadBlockId,
     RaptorQDecodeFailed,
-    BadBlockInfo
+    BadBlockInfo,
 }
 
 pub struct RaptorQDecoder {
@@ -25,21 +19,30 @@ impl RaptorQDecoder {
     pub fn new(block_info_vec: Vec<BlockInfo>) -> Result<RaptorQDecoder, RaptorQDecoderError> {
         // validate the block info vector, it should be a permutation of (0..num_blocks-1)
         // pepega strat: sort and assert equality to 1..block_info_vec.len()
-        let block_ids: Vec<usize> = block_info_vec.iter().map(|block_info| block_info.block_id as usize).collect();
+        let block_ids: Vec<usize> = block_info_vec
+            .iter()
+            .map(|block_info| block_info.block_id as usize)
+            .collect();
         if block_ids != (0..block_info_vec.len()).collect::<Vec<usize>>() {
             return Err(RaptorQDecoderError::BadBlockInfo);
         }
 
-        let block_decoder_results: Result<Vec<BlockDecoder>, RaptorQDecoderError> = block_info_vec.into_iter().map(BlockDecoder::new).collect();
-        match block_decoder_results {
-            Ok(block_decoders) => Ok(RaptorQDecoder{block_decoder_data: block_decoders.into_iter().map(|x| (x, Vec::new())).collect()}),
-            Err(error) => Err(error),
-        }
+        Ok(RaptorQDecoder {
+            block_decoder_data: block_info_vec
+                .into_iter()
+                .map(BlockDecoder::new)
+                .collect::<Result<Vec<BlockDecoder>, RaptorQDecoderError>>()?
+                .into_iter()
+                .map(|x| (x, Vec::new()))
+                .collect(),
+        })
     }
 
     fn consume_block(&mut self, block: EncodedBlock) -> usize {
         if (block.block_id as usize) < self.block_decoder_data.len() {
-            self.block_decoder_data[block.block_id as usize].1.push(block);
+            self.block_decoder_data[block.block_id as usize]
+                .1
+                .push(block);
             return 1;
         }
 
@@ -48,15 +51,22 @@ impl RaptorQDecoder {
 
     /// consume some blocks into the decoder, report back how many blocks have been consumed
     pub fn consume_blocks(&mut self, blocks: Vec<EncodedBlock>) -> usize {
-        blocks.into_iter().map(|block| self.consume_block(block)).sum()
+        blocks
+            .into_iter()
+            .map(|block| self.consume_block(block))
+            .sum()
     }
 
-    /// Attempt to decode the blocks. 
+    /// Attempt to decode the blocks.
     pub fn decode_blocks(&mut self) -> Result<Vec<u8>, RaptorQDecoderError> {
-        match self.block_decoder_data.iter().map(|(decoder, blocks)| decoder.decode_blocks(blocks.to_vec())).collect::<Result<Vec<Vec<u8>>, RaptorQDecoderError>>() {
-            Ok(block_data_vec) => Ok(block_data_vec.into_iter().flatten().collect()),
-            Err(err) => Err(err),
-        }
+        Ok(self
+            .block_decoder_data
+            .par_iter()
+            .map(|(decoder, blocks)| decoder.decode_blocks(blocks.to_vec()))
+            .collect::<Result<Vec<Vec<u8>>, RaptorQDecoderError>>()?
+            .into_iter()
+            .flatten()
+            .collect())
     }
 }
 
@@ -68,10 +78,13 @@ pub struct BlockDecoder {
 
 impl BlockDecoder {
     pub fn new(block_info: BlockInfo) -> Result<BlockDecoder, RaptorQDecoderError> {
-        Ok(BlockDecoder{block_info})
+        Ok(BlockDecoder { block_info })
     }
 
-    fn extract_packet(block: EncodedBlock, block_id: u32) -> Result<EncodingPacket, RaptorQDecoderError> {
+    fn extract_packet(
+        block: EncodedBlock,
+        block_id: u32,
+    ) -> Result<EncodingPacket, RaptorQDecoderError> {
         if block.block_id != block_id {
             return Err(RaptorQDecoderError::BadBlockId);
         }
@@ -79,24 +92,28 @@ impl BlockDecoder {
         Ok(block.data)
     }
 
-    // the raptorq wants an owned Vec<EncodingPacket>, so we create this for it. 
-    fn extract_packets(blocks: Vec<EncodedBlock>, block_id: u32) -> Result<Vec<EncodingPacket>, RaptorQDecoderError> {
-        blocks.into_iter().map(|block| BlockDecoder::extract_packet(block, block_id)).collect()
+    // the raptorq wants an owned Vec<EncodingPacket>, so we create this for it.
+    fn extract_packets(
+        blocks: Vec<EncodedBlock>,
+        block_id: u32,
+    ) -> Result<Vec<EncodingPacket>, RaptorQDecoderError> {
+        blocks
+            .into_iter()
+            .map(|block| BlockDecoder::extract_packet(block, block_id))
+            .collect()
     }
 
     /// static method for decoding data
-    pub fn decode_data(block_info: &BlockInfo, blocks: Vec<EncodedBlock>) -> Result<Vec<u8>, RaptorQDecoderError> {
-        let mut decoder = SourceBlockDecoder::new2(0, &block_info.config, block_info.padded_size as u64);
+    pub fn decode_data(
+        block_info: &BlockInfo,
+        blocks: Vec<EncodedBlock>,
+    ) -> Result<Vec<u8>, RaptorQDecoderError> {
+        let mut decoder =
+            SourceBlockDecoder::new2(0, &block_info.config, block_info.padded_size as u64);
 
-        let packets = match BlockDecoder::extract_packets(blocks, block_info.block_id) {
-            Ok(p) => p,
-            Err(err) => return Err(err),
-        };
-
-        let mut decoded_data = match decoder.decode(packets) {
-            None => return Err(RaptorQDecoderError::RaptorQDecodeFailed),
-            Some(data) => data
-        };
+        let mut decoded_data = decoder
+            .decode(BlockDecoder::extract_packets(blocks, block_info.block_id)?)
+            .ok_or(RaptorQDecoderError::RaptorQDecodeFailed)?;
 
         assert_eq!(decoded_data.len(), block_info.padded_size);
         decoded_data.truncate(block_info.payload_size);

--- a/src/codec/encoder.rs
+++ b/src/codec/encoder.rs
@@ -1,55 +1,129 @@
-#[cfg(feature = "serde_support")]
-use serde::{Deserialize, Serialize};
-use raptorq::{EncodingPacket, ObjectTransmissionInformation, SourceBlockEncoder, SourceBlockEncodingPlan};
-use std::cmp;
 use super::consts::*;
-use rand::{thread_rng, Rng, seq::SliceRandom};
+use anyhow;
+use anyhow::Result;
+use rand::{seq::SliceRandom, thread_rng, Rng};
+use raptorq::{
+    EncodingPacket, ObjectTransmissionInformation, SourceBlockEncoder, SourceBlockEncodingPlan,
+};
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_json;
+use std::cmp;
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CachedEncodingPlan {
+    source_symbol_count: u16,
+    plan: SourceBlockEncodingPlan,
+}
+
+fn load_cached_encoding_plan(path: &path::PathBuf) -> Result<CachedEncodingPlan> {
+    let json_data = fs::read_to_string(path)?;
+
+    Ok(serde_json::from_str::<CachedEncodingPlan>(&json_data)?)
+}
+
+fn load_cached_encoding_plans(dir: &str) -> Result<Vec<CachedEncodingPlan>> {
+    let plan_files: Vec<path::PathBuf> = fs::read_dir(dir)?
+        .map(|res| res.map(|e| e.path()))
+        .collect::<Result<Vec<_>, io::Error>>()?
+        .into_iter()
+        .filter(|p| {
+            p.is_file() && p.extension().and_then(std::ffi::OsStr::to_str) == Some("json")
+        })
+        .collect();
+
+    plan_files.iter().map(load_cached_encoding_plan).collect()
+}
+
+pub fn load_encoding_plans(dir: &str) -> Result<HashMap<u16, SourceBlockEncodingPlan>> {
+    let mut hashmap: HashMap<u16, SourceBlockEncodingPlan> = HashMap::new();
+
+    for cached_plan in load_cached_encoding_plans(dir)? {
+        hashmap.insert(cached_plan.source_symbol_count, cached_plan.plan);
+    }
+
+    Ok(hashmap)
+}
+
+fn save_encoding_plan(dir: &str, cached_plan: CachedEncodingPlan) -> Result<()> {
+    let file_path = path::Path::new(dir).join(format!("plan_{}.json", cached_plan.source_symbol_count));
+
+    Ok(fs::write(file_path, serde_json::to_string(&cached_plan)?)?)
+}
+
+pub fn save_encoding_plans(dir: &str, plans: HashMap<u16, SourceBlockEncodingPlan>) -> Result<()> {
+    let cached_plans: Vec<CachedEncodingPlan> = plans.iter().map(|(k, v)| CachedEncodingPlan {source_symbol_count: *k, plan: v.clone()}).collect();
+
+    for cached_plan in cached_plans {
+        save_encoding_plan(dir, cached_plan)?;
+    }
+
+    Ok(())
+}
+
+struct EncodingPlanCache {
+    lock: std::sync::RwLock<usize>,
+    plans: HashMap<u16, SourceBlockEncodingPlan>,
+}
 
 pub struct RaptorQEncoder {
     block_encoders: Vec<BlockEncoder>,
+    encoding_plan_cache: EncodingPlanCache,
 }
 
-/// RaptorQ data encoder. 
+/// RaptorQ data encoder.
 impl RaptorQEncoder {
-    pub fn new(packet_size: u16, data: &[u8]) -> Result<RaptorQEncoder, RaptorQEncoderError> {
-        let block_size = MAX_SYMBOLS_IN_BLOCK * packet_size as usize;
+    pub fn new(packet_size: u16, data: &[u8], encoding_plans: HashMap<u16, SourceBlockEncodingPlan>) -> Result<RaptorQEncoder, RaptorQEncoderError> {
+        let block_size = MAX_SYMBOLS_IN_BLOCK as usize * packet_size as usize;
 
         let data_chunks: Vec<Vec<u8>> = data.chunks(block_size).map(|x| x.to_vec()).collect();
 
-        let encoder_results: Result<Vec<BlockEncoder>, RaptorQEncoderError> = data_chunks.par_iter().enumerate().map(|(i, data_chunk)| BlockEncoder::new(i as u32, packet_size, data_chunk.to_vec())).collect();
+        let mut encoding_plan_cache = EncodingPlanCache {lock:std::sync::RwLock::new(0), plans: encoding_plans};
+
+        let encoder_results: Result<Vec<BlockEncoder>, RaptorQEncoderError> = data_chunks.iter().enumerate().map(|(i, chunk)| (i, chunk, &encoding_plan_cache))
+            .par_bridge()
+            .map(|(i, data_chunk, mut cache_ref)| BlockEncoder::new(i as u32, packet_size, data_chunk.to_vec(), &cache_ref))
+            .collect();
+
 
         match encoder_results {
-            Ok(block_encoders) =>
-                Ok(RaptorQEncoder {
-                block_encoders,
-            }),
+            Ok(block_encoders) => Ok(RaptorQEncoder { block_encoders, encoding_plan_cache}),
             Err(error) => Err(error),
         }
     }
 
     pub fn generate_encoded_blocks(&self) -> Vec<EncodedBlock> {
-        // shuffle blocks so multiple encoders don't all send blocks in the same order. Transposing would in theory help here, but I don't know how costly that is. 
-        let mut encoded_blocks: Vec<Vec<EncodedBlock>> = self.block_encoders.par_iter().map(|encoder| encoder.generate_encoded_blocks()).collect();
+        // shuffle blocks so multiple encoders don't all send blocks in the same order. Transposing would in theory help here, but I don't know how costly that is.
+        let mut encoded_blocks: Vec<Vec<EncodedBlock>> = self
+            .block_encoders
+            .par_iter()
+            .map(|encoder| encoder.generate_encoded_blocks())
+            .collect();
         encoded_blocks.shuffle(&mut thread_rng());
         encoded_blocks.into_iter().flatten().collect()
     }
 
     pub fn get_block_info_vec(&self) -> Vec<BlockInfo> {
-        self.block_encoders.par_iter().map(|x| x.get_block_info()).collect()
+        self.block_encoders
+            .par_iter()
+            .map(|x| x.get_block_info())
+            .collect()
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RaptorQEncoderError {
-    /// Packet size provided is not valid. 
-    /// TODO: make errors more useful. 
+    /// Packet size provided is not valid.
+    /// TODO: make errors more useful.
     InvalidPacketSize,
     DataSizeTooLarge,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub struct EncodedBlock {
     /// Index of this block in overall payload
     pub block_id: u32,
@@ -58,8 +132,7 @@ pub struct EncodedBlock {
 }
 
 /// Information about the payload encoded by a BlockEncoder. Needs to be transmitted from the encoder to the decoder.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockInfo {
     /// Size of payload in data.
     pub payload_size: usize,
@@ -67,7 +140,7 @@ pub struct BlockInfo {
     pub padded_size: usize,
     /// RaptorQ configuration object
     pub config: ObjectTransmissionInformation,
-    // Index of this block in overall payload. 
+    // Index of this block in overall payload.
     pub block_id: u32,
 }
 
@@ -84,14 +157,19 @@ pub struct BlockEncoder {
     /// Encoded packet size. Also the symbol size used for BlockEncoder.
     packet_size: u16,
     /// Encoding plan - helps for small RAPTORQ_MAX_SYMBOLS_IN_BLOCK values.
-    /// TODO: validate with real data. 
+    /// TODO: validate with real data.
     encoding_plan: SourceBlockEncodingPlan,
 }
 
 impl BlockEncoder {
     /// Creates a BlockEncoder with a given data payload and packet size
-    /// We use packet size == symbol size. 
-    pub fn new(block_id: u32, packet_size: u16, mut data: Vec<u8>) -> Result<BlockEncoder, RaptorQEncoderError> {
+    /// We use packet size == symbol size.
+    pub fn new(
+        block_id: u32,
+        packet_size: u16,
+        mut data: Vec<u8>,
+        encoding_plan_cache: &mut EncodingPlanCache
+    ) -> Result<BlockEncoder, RaptorQEncoderError> {
         if packet_size % ALIGNMENT as u16 != 0 || packet_size < MIN_PACKET_SIZE {
             return Err(RaptorQEncoderError::InvalidPacketSize);
         }
@@ -106,13 +184,21 @@ impl BlockEncoder {
             );
         }
 
-        let num_symbols = data.len() / packet_size as usize;
+        let num_symbols = (data.len() / packet_size as usize) as u16;
 
         if num_symbols > MAX_SYMBOLS_IN_BLOCK {
             return Err(RaptorQEncoderError::DataSizeTooLarge);
         }
 
-        let encoding_plan = SourceBlockEncodingPlan::generate(num_symbols as u16);
+        let (update_cache, encoding_plan) = match (encoding_plan_cache.lock.read().unwrap(), encoding_plan_cache.plans.get(&num_symbols)) {
+            (_, Some(plan)) => (false, plan.clone()),
+            (_, None) => (true, SourceBlockEncodingPlan::generate(num_symbols)),
+        };
+        
+        if update_cache {
+            encoding_plan_cache.lock.write().unwrap();
+            encoding_plan_cache.plans.insert(num_symbols, encoding_plan.clone());
+        }
 
         /*
          * ObjectTransmissionInformation is described roughly by the RFC spec:
@@ -145,30 +231,53 @@ impl BlockEncoder {
         })
     }
 
-    fn add_packets(blocks:&mut Vec<EncodedBlock>, mut packets: Vec<EncodingPacket>, block_id: u32) {
+    fn add_packets(
+        blocks: &mut Vec<EncodedBlock>,
+        mut packets: Vec<EncodingPacket>,
+        block_id: u32,
+    ) {
         while match packets.pop() {
             None => false,
             Some(packet) => {
-                blocks.push(EncodedBlock{block_id, data: packet});
+                blocks.push(EncodedBlock {
+                    block_id,
+                    data: packet,
+                });
                 true
-            },
+            }
         } {}
     }
 
     /// static method for encoding data
-    pub fn encode_data(config: &ObjectTransmissionInformation, plan: &SourceBlockEncodingPlan, data: &[u8], packet_size: u16, block_id: u32) -> Vec<EncodedBlock> {
+    pub fn encode_data(
+        config: &ObjectTransmissionInformation,
+        plan: &SourceBlockEncodingPlan,
+        data: &[u8],
+        packet_size: u16,
+        block_id: u32,
+    ) -> Vec<EncodedBlock> {
         let encoder = SourceBlockEncoder::with_encoding_plan2(0, config, data, plan);
         let packets_to_send = data.len() / packet_size as usize;
-        let mut blocks :Vec<EncodedBlock> = Vec::new();
+        let mut blocks: Vec<EncodedBlock> = Vec::new();
 
         let start_index = thread_rng().gen_range(0..RAPTORQ_ENCODING_SYMBOL_ID_MAX);
-        
-        let packets_created = cmp::min(RAPTORQ_ENCODING_SYMBOL_ID_MAX - start_index, packets_to_send);
 
-        BlockEncoder::add_packets(&mut blocks, encoder.repair_packets(start_index as u32, packets_created as u32), block_id);
+        let packets_created = cmp::min(
+            RAPTORQ_ENCODING_SYMBOL_ID_MAX - start_index,
+            packets_to_send,
+        );
 
+        BlockEncoder::add_packets(
+            &mut blocks,
+            encoder.repair_packets(start_index as u32, packets_created as u32),
+            block_id,
+        );
         if packets_created < packets_to_send {
-            BlockEncoder::add_packets(&mut blocks, encoder.repair_packets(0, (packets_to_send - packets_created) as u32), block_id);
+            BlockEncoder::add_packets(
+                &mut blocks,
+                encoder.repair_packets(0, (packets_to_send - packets_created) as u32),
+                block_id,
+            );
         }
 
         blocks
@@ -176,7 +285,13 @@ impl BlockEncoder {
 
     /// Creates packets to transmit.
     pub fn generate_encoded_blocks(&self) -> Vec<EncodedBlock> {
-        BlockEncoder::encode_data(&self.config, &self.encoding_plan, &self.data, self.packet_size, self.block_id)
+        BlockEncoder::encode_data(
+            &self.config,
+            &self.encoding_plan,
+            &self.data,
+            self.packet_size,
+            self.block_id,
+        )
     }
 
     /// Gets information about payload required for decoding.

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,3 +1,3 @@
-pub mod encoder;
-pub mod decoder;
 pub mod consts;
+pub mod decoder;
+pub mod encoder;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,25 +15,40 @@ fn main() {
     println!("I do nothing for now.");
     let packet_size: u16 = 1280;
     let num_blocks: usize = 30;
-    let data_size: usize = codec::consts::MAX_SYMBOLS_IN_BLOCK * packet_size as usize * num_blocks;
+    let data_size: usize = codec::consts::MAX_SYMBOLS_IN_BLOCK as usize * packet_size as usize * num_blocks;
+
+
     println!("data size {}", data_size.to_formatted_string(&Locale::en));
     // for this test to work, we expect NO PADDING!
     assert_eq!(data_size % packet_size as usize, 0);
     println!("Generating data...");
+    let mut now = Instant::now();
     let data = gen_data(data_size);
+    println!("Generated data in {} ms", now.elapsed().as_millis());
+
+    println!("Loading cached SourceBlockEncodingPlans");
+    now = Instant::now();
+    let mut plans = codec::encoder::load_encoding_plans(".encoding_plan_cache/").unwrap();
+    println!("Loaded {} cached SourceBlockEncodingPlans in {} ms", plans.keys().len(), now.elapsed().as_millis());
+    
 
     println!("Creating encoder...");
-    let mut now = Instant::now();
-    let encoder = match codec::encoder::RaptorQEncoder::new(packet_size, &data) {
+    let encoder = match codec::encoder::RaptorQEncoder::new(packet_size, &data, Some(&mut plans)) {
         Ok(succ) => succ,
-        Err(error) => panic!("Failed to create encoder, error {}", error as u32),
+        Err(error) => panic!("Failed to create encoder, error {}", error),
     };
     println!("Created encoder in {} ms", now.elapsed().as_millis());
+
+    println!("Saving updated SourceBlockEncodingPlans");
+    now = Instant::now();
+    codec::encoder::save_encoding_plans(".encoding_plan_cache/", &plans).unwrap();
+    println!("Saved {} cached SourceBlockEncodingPlans in {} ms", plans.keys().len(), now.elapsed().as_millis());
+
     println!("Creating decoder...");
     now = Instant::now();
     let mut decoder = match codec::decoder::RaptorQDecoder::new(encoder.get_block_info_vec()) {
         Ok(succ) => succ,
-        Err(error) => panic!("Failed to create decoder, error {}", error as u32),
+        Err(error) => panic!("Failed to create decoder, error {}", error),
     };
     println!("Created decoder in {} ms", now.elapsed().as_millis());
 
@@ -50,7 +65,7 @@ fn main() {
 
     let recovered_data = match result {
         Ok(data) => data,
-        Err(error) => panic!("Failed to decode, error {}", error as u32),
+        Err(error) => panic!("Failed to decode, error {}", error),
     };
 
     assert_eq!(data, recovered_data);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod codec;
-use std::time::Instant;
-use rand::Rng;
 use num_format::{Locale, ToFormattedString};
+use rand::Rng;
+use std::time::Instant;
 
 fn gen_data(len: usize) -> Vec<u8> {
     let mut data: Vec<u8> = Vec::with_capacity(len);
@@ -13,15 +13,12 @@ fn gen_data(len: usize) -> Vec<u8> {
 
 fn main() {
     println!("I do nothing for now.");
-    let packet_size: u16 = 16384;
-    let num_blocks: usize = 3;
+    let packet_size: u16 = 1280;
+    let num_blocks: usize = 30;
     let data_size: usize = codec::consts::MAX_SYMBOLS_IN_BLOCK * packet_size as usize * num_blocks;
-    
     println!("data size {}", data_size.to_formatted_string(&Locale::en));
-    
     // for this test to work, we expect NO PADDING!
     assert_eq!(data_size % packet_size as usize, 0);
-    
     println!("Generating data...");
     let data = gen_data(data_size);
 
@@ -32,7 +29,6 @@ fn main() {
         Err(error) => panic!("Failed to create encoder, error {}", error as u32),
     };
     println!("Created encoder in {} ms", now.elapsed().as_millis());
-    
     println!("Creating decoder...");
     now = Instant::now();
     let mut decoder = match codec::decoder::RaptorQDecoder::new(encoder.get_block_info_vec()) {

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -21,12 +21,12 @@ fn test_block_encoder_invalid_packet_size() {
     let data_size: usize = 128 * 1024;
     let data = gen_data(data_size);
 
-    match BlockEncoder::new(0, packet_size, data.clone()) {
+    match BlockEncoder::new(0, packet_size, data.clone(), None) {
         Ok(_) => panic!(
             "Should have failed to use packet_size {} with alignment {}",
             packet_size, ALIGNMENT
         ),
-        Err(error) => assert_eq!(error, RaptorQEncoderError::InvalidPacketSize),
+        Err(_) => (),
     };
 }
 
@@ -36,15 +36,15 @@ fn test_block_encoder_single_peer() {
     let data_size: usize = 128 * 1024;
     let data = gen_data(data_size);
 
-    let encoder = match BlockEncoder::new(0, packet_size, data.clone()) {
+    let encoder = match BlockEncoder::new(0, packet_size, data.clone(), None) {
         Ok(succ) => succ,
-        Err(error) => panic!("Failed to create encoder, error {}", error as u32),
+        Err(error) => panic!("Failed to create encoder: {}", error),
     };
     let blocks = encoder.generate_encoded_blocks();
 
     match BlockDecoder::decode_data(&encoder.get_block_info(), blocks) {
         Ok(recovered_data) => assert_eq!(arr_eq(&recovered_data, &data), true),
-        Err(error) => panic!("Failed to decode data, err {}", error as u32),
+        Err(error) => panic!("Failed to decode data: {}", error),
     }
 }
 
@@ -54,9 +54,9 @@ fn test_block_encoder_multiple_peers() {
     let data_size: usize = 128 * 1024;
     let data = gen_data(data_size);
 
-    let encoder = match BlockEncoder::new(0, packet_size, data.clone()) {
+    let encoder = match BlockEncoder::new(0, packet_size, data.clone(), None) {
         Ok(succ) => succ,
-        Err(error) => panic!("Failed to create encoder, error {}", error as u32),
+        Err(error) => panic!("Failed to create encoder: {}", error),
     };
     // pretend we have three different client streams
     let mut blocks = encoder.generate_encoded_blocks();
@@ -76,7 +76,7 @@ fn test_block_encoder_multiple_peers() {
     // recover data
     match BlockDecoder::decode_data(&encoder.get_block_info(), blocks) {
         Ok(recovered_data) => assert_eq!(arr_eq(&recovered_data, &data), true),
-        Err(error) => panic!("Failed to decode data, err {}", error as u32),
+        Err(error) => panic!("Failed to decode data: {}", error),
     }
 }
 
@@ -86,20 +86,20 @@ fn test_block_decode_single_client() {
     let data_size: usize = 128 * 1024;
     let data = gen_data(data_size);
 
-    let encoder = match BlockEncoder::new(0, packet_size, data.clone()) {
+    let encoder = match BlockEncoder::new(0, packet_size, data.clone(), None) {
         Ok(succ) => succ,
-        Err(error) => panic!("Failed to create encoder, error {}", error as u32),
+        Err(error) => panic!("Failed to create encoder: {}", error),
     };
 
     let blocks = encoder.generate_encoded_blocks();
 
     let decoder = match BlockDecoder::new(encoder.get_block_info()) {
         Ok(succ) => succ,
-        Err(error) => panic!("Failed to create encoder, error {}", error as u32),
+        Err(error) => panic!("Failed to create encoder: {}", error),
     };
 
     match decoder.decode_blocks(blocks) {
         Ok(recovered_data) => assert_eq!(arr_eq(&recovered_data, &data), true),
-        Err(error) => panic!("Failed to decode data, err {}", error as u32),
+        Err(error) => panic!("Failed to decode data: {}", error),
     }
 }

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -1,7 +1,7 @@
-use raptor_cdn_lib::codec::encoder::*;
-use raptor_cdn_lib::codec::decoder::*;
-use raptor_cdn_lib::codec::consts::*;
 use rand::Rng;
+use raptor_cdn_lib::codec::consts::*;
+use raptor_cdn_lib::codec::decoder::*;
+use raptor_cdn_lib::codec::encoder::*;
 
 fn gen_data(len: usize) -> Vec<u8> {
     let mut data: Vec<u8> = Vec::with_capacity(len);
@@ -12,7 +12,7 @@ fn gen_data(len: usize) -> Vec<u8> {
 }
 
 fn arr_eq(data1: &[u8], data2: &[u8]) -> bool {
-    data1.iter().zip(data2.iter()).all(|(a,b)| a == b)
+    data1.iter().zip(data2.iter()).all(|(a, b)| a == b)
 }
 
 #[test]
@@ -20,9 +20,12 @@ fn test_block_encoder_invalid_packet_size() {
     let packet_size: u16 = 1337;
     let data_size: usize = 128 * 1024;
     let data = gen_data(data_size);
-    
+
     match BlockEncoder::new(0, packet_size, data.clone()) {
-        Ok(_) => panic!("Should have failed to use packet_size {} with alignment {}", packet_size, ALIGNMENT),
+        Ok(_) => panic!(
+            "Should have failed to use packet_size {} with alignment {}",
+            packet_size, ALIGNMENT
+        ),
         Err(error) => assert_eq!(error, RaptorQEncoderError::InvalidPacketSize),
     };
 }
@@ -32,13 +35,13 @@ fn test_block_encoder_single_peer() {
     let packet_size: u16 = 1280;
     let data_size: usize = 128 * 1024;
     let data = gen_data(data_size);
-    
+
     let encoder = match BlockEncoder::new(0, packet_size, data.clone()) {
         Ok(succ) => succ,
         Err(error) => panic!("Failed to create encoder, error {}", error as u32),
     };
     let blocks = encoder.generate_encoded_blocks();
-    
+
     match BlockDecoder::decode_data(&encoder.get_block_info(), blocks) {
         Ok(recovered_data) => assert_eq!(arr_eq(&recovered_data, &data), true),
         Err(error) => panic!("Failed to decode data, err {}", error as u32),
@@ -50,7 +53,7 @@ fn test_block_encoder_multiple_peers() {
     let packet_size: u16 = 1280;
     let data_size: usize = 128 * 1024;
     let data = gen_data(data_size);
-    
+
     let encoder = match BlockEncoder::new(0, packet_size, data.clone()) {
         Ok(succ) => succ,
         Err(error) => panic!("Failed to create encoder, error {}", error as u32),
@@ -59,17 +62,17 @@ fn test_block_encoder_multiple_peers() {
     let mut blocks = encoder.generate_encoded_blocks();
     let mut blocks_2 = encoder.generate_encoded_blocks();
     let mut blocks_3 = encoder.generate_encoded_blocks();
-    
+
     // lose 2/3 of each stream, to simulate receiving partial data from multiple clients
     let packets_per_client = data_size / (3 * packet_size as usize) + 1;
     blocks.truncate(packets_per_client);
     blocks_2.truncate(packets_per_client);
     blocks_3.truncate(packets_per_client);
-    
+
     // recombine into single stream
     blocks.append(&mut blocks_2);
     blocks.append(&mut blocks_3);
-    
+
     // recover data
     match BlockDecoder::decode_data(&encoder.get_block_info(), blocks) {
         Ok(recovered_data) => assert_eq!(arr_eq(&recovered_data, &data), true),
@@ -82,14 +85,14 @@ fn test_block_decode_single_client() {
     let packet_size: u16 = 1280;
     let data_size: usize = 128 * 1024;
     let data = gen_data(data_size);
-    
+
     let encoder = match BlockEncoder::new(0, packet_size, data.clone()) {
         Ok(succ) => succ,
         Err(error) => panic!("Failed to create encoder, error {}", error as u32),
     };
 
     let blocks = encoder.generate_encoded_blocks();
-    
+
     let decoder = match BlockDecoder::new(encoder.get_block_info()) {
         Ok(succ) => succ,
         Err(error) => panic!("Failed to create encoder, error {}", error as u32),


### PR DESCRIPTION
Decoding without --release is still very slow in the decode path, but a lot of time was saved by caching the encoding plan. In --release this may not be necessary, but it still could help depending on the workload. 